### PR TITLE
Add Java compiler version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,4 +43,9 @@
         </plugins>
     </build>
 
+     <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
 </project>


### PR DESCRIPTION
If I do not specify Java version, the compiler will understand that I am using Java 5. I think it will be safer with this additional configuration.